### PR TITLE
Excluded org.mortbay.jetty 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -69,4 +69,6 @@ libraryDependencies ++= Seq(
   "org.mockito" % "mockito-core" % versions.mockito % "test",
   "org.scalatest" %% "scalatest" % versions.scalatest % "test",
   "org.specs2" %% "specs2" % versions.specs2 % "test"
+).map(
+  _.excludeAll(ExclusionRule(organization = "org.mortbay.jetty"))
 )


### PR DESCRIPTION
which seems to be creating a conflict throwing "javax.servlet.FilterRegistration"'s signer information does not match signer information of other classes in the same package java.lang.SecurityException:
